### PR TITLE
feat: Add APP_REDIS_URL as a potential ENV for this library

### DIFF
--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -71,7 +71,7 @@ module Turnout
 
     def default_redis_settings(options)
       return options if options&.fetch(:url){false} || options&.fetch(:host){false}
-      url = ENV['REDIS_PROVIDER'] || ENV['REDIS_URL'] || ENV['REDIS_SERVER']
+      url = ENV['APP_REDIS_URL'] || ENV['REDIS_PROVIDER'] || ENV['REDIS_URL'] || ENV['REDIS_SERVER']
       if (url)
         options ||= {}
         options = options.merge(url: url)


### PR DESCRIPTION
A little change that makes this library accept the APP_REDIS_URL env variable. I'll open another PR that gives this gem the ability to receive a custom Redis URL from the options.